### PR TITLE
fix: add padding offset to P matrix in Metric3D prepare_input (fixes #9)

### DIFF
--- a/ros2_vision_inference/ros2_vision_inference.py
+++ b/ros2_vision_inference/ros2_vision_inference.py
@@ -180,7 +180,10 @@ class Metric3DThread(BaseInferenceThread):
 
         P = self.P.copy()
         P[0:2, :] = P[0:2, :] * scale
-        
+        # Apply padding offset: principal point shifts when image is centered in padded canvas
+        P[0, 2] += pad_w_half
+        P[1, 2] += pad_h_half
+
         # Create P_inv
         P_expanded = np.eye(4)
         P_expanded[0:3, 0:4] = P


### PR DESCRIPTION
When resizing and padding the input image for Metric3D inference, the projection matrix P was scaled for the resize step but not adjusted for the padding offset. copyMakeBorder centers the resized image in the padded canvas, shifting the principal point (cx, cy) by (pad_w_half, pad_h_half). This fix adds those offsets to P[0,2] and P[1,2] so the camera intrinsics correctly correspond to the actual input image coordinates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized math change to Metric3D preprocessing; main risk is shifted depth/point cloud geometry if padding assumptions differ from the model’s expected intrinsics.
> 
> **Overview**
> Fixes Metric3D input preprocessing by updating the scaled projection matrix `P` to account for the centering padding added via `cv2.copyMakeBorder`.
> 
> Specifically, after resizing and padding, it offsets the principal point (`P[0,2]`, `P[1,2]`) by `(pad_w_half, pad_h_half)` so `P`/`P_inv` correspond to the padded input image coordinates used for inference.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a0aaa8cd20d660ee6e3adcd2347a40c3dc0c100. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->